### PR TITLE
Fix Homepage Headline Contrast

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -48,7 +48,7 @@ export default function Home() {
   return (
     <div className="flex flex-col -mt-5">
       <div className="relative flex h-screen justify-center items-center">
-        <div className="absolute w-full h-full">
+        <div className="absolute w-full h-full opacity-50">
           <Image
             src={HomePageBackgroundImage}
             alt={HomePageBackgroundImage}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,7 +4,7 @@
 @tailwind utilities;
 
 .text-stroke-outside {
-  -webkit-text-stroke: 5px white;
+  -webkit-text-stroke: 3px white;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Resolves #50

The opacity was 100% on the background image whereas on Figma it was 50%. This is why the contrast was off. Now:

<img width="1676" alt="Screen Shot 2022-09-17 at 3 18 20 PM" src="https://user-images.githubusercontent.com/47438886/190876755-29557e11-0409-4f95-9686-b24663675e7b.png">
