### PR TITLE
Removing scroll on mobile view

### DIFF
--- a/components/Sponsors.jsx
+++ b/components/Sponsors.jsx
@@ -11,7 +11,7 @@ import {
 
 const SPONSORS_CONTAINER = 'bg-white flex flex-col items-center py-10 md:py-20';
 const HEADING_CONTAINER = 'flex flex-row justify-center mb-10 ml-5';
-const SPONSORS_LEVEL_CONTAINER = 'flex flex-row justify-center items-center my-5';
+const SPONSORS_LEVEL_CONTAINER = 'flex flex-row justify-center items-center my-5 flex-wrap';
 const CONTENT_CONTAINER = 'my-10 font-medium w-1/2 text-center';
 const UNDERLINE_CONTAINER = 'mb-10';
 const UNDERLINE_PROPERTIES = {

--- a/data/sponsors.js
+++ b/data/sponsors.js
@@ -1,26 +1,22 @@
-import Benevity from "../public/sponsor_logos/Benevity.png";
-import Cisco from "../public/sponsor_logos/Cisco Secure.jpg";
-import Schulich from "../public/sponsor_logos/Schulich School of Engineering.png";
-import ATB from "../public/sponsor_logos/atb.jpg";
-import FacultyOfScience from "../public/sponsor_logos/UC Faculty of Science.jpg";
+import Benevity from '../public/sponsor_logos/Benevity.png';
+import Cisco from '../public/sponsor_logos/Cisco Secure.jpg';
+import Schulich from '../public/sponsor_logos/Schulich School of Engineering.png';
+import ATB from '../public/sponsor_logos/atb.jpg';
+import FacultyOfScience from '../public/sponsor_logos/UC Faculty of Science.jpg';
 
 // Multiplier is the value you need to multiply height by to get width
 export const GOLD_SPONSORS_ONE = [
-  { file: ATB, multiplier: 1.42, height: 120, website: "atb.com" },
-  { file: Benevity, multiplier: 3.216, height: 90, website: "benevity.com" },
+  { file: ATB, multiplier: 1.42, height: 120, website: 'atb.com' },
+  { file: Benevity, multiplier: 3.216, height: 90, website: 'benevity.com' },
 ];
 
-export const GOLD_SPONSORS_TWO = [
-  { file: Cisco, multiplier: 3.41, height: 120, website: "cisco.com" },
-];
+export const GOLD_SPONSORS_TWO = [{ file: Cisco, multiplier: 3.41, height: 120, website: 'cisco.com' }];
 
 export const SILVER_SPONSORS_ONE = [
-  { file: Schulich, multiplier: 1.45, height: 115, website: "schulich.ucalgary.ca" },
-  { file: FacultyOfScience, multiplier: 4.26, height: 115, website: "https://science.ucalgary.ca/" },
+  { file: Schulich, multiplier: 1.45, height: 115, website: 'schulich.ucalgary.ca' },
+  { file: FacultyOfScience, multiplier: 4.26, height: 115, website: 'science.ucalgary.ca' },
 ];
 
-export const SILVER_SPONSORS_TWO = [
-];
+export const SILVER_SPONSORS_TWO = [];
 
-export const BRONZE_SPONSORS = [
-];
+export const BRONZE_SPONSORS = [];

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,22 +1,22 @@
 /* eslint-disable @next/next/no-img-element */
-import Image from "next/image";
-import { EffectCards } from "swiper";
-import { SwiperSlide } from "swiper/react";
-import Button from "../components/Button";
-import Carousel from "../components/Carousel";
-import Tile from "../components/Tile";
-import Heading from "../components/Heading";
-import TextSection from "../components/TextSection";
-import Sponsors from "../components/Sponsors";
-import { UnderlineTypes } from "../utils/underlineType";
-import HomePageBackgroundImage from "../public/images/homepage/homepage_background.png";
+import Image from 'next/image';
+import { EffectCards } from 'swiper';
+import { SwiperSlide } from 'swiper/react';
+import Button from '../components/Button';
+import Carousel from '../components/Carousel';
+import Tile from '../components/Tile';
+import Heading from '../components/Heading';
+import TextSection from '../components/TextSection';
+import Sponsors from '../components/Sponsors';
+import { UnderlineTypes } from '../utils/underlineType';
+import HomePageBackgroundImage from '../public/images/homepage/homepage_background.png';
 
-const LOGO_SVG_TOP = "/svgs/homepage/with_logo_top.svg";
-const LOGO_SVG_BOTTOM = "/svgs/homepage/with_logo_bottom.svg";
-const COMMUNITY_SVG = "/svgs/homepage/coding_community.svg";
+const LOGO_SVG_TOP = '/svgs/homepage/with_logo_top.svg';
+const LOGO_SVG_BOTTOM = '/svgs/homepage/with_logo_bottom.svg';
+const COMMUNITY_SVG = '/svgs/homepage/coding_community.svg';
 const ROLE_TILE_SIZE = 300;
-const ROLES = ["Development", "Marketing", "Design", "Events"];
-const STANDOUT_TEXT_CLASSES = "font-bold text-[#7055FD]";
+const ROLES = ['Development', 'Marketing', 'Design', 'Events'];
+const STANDOUT_TEXT_CLASSES = 'font-bold text-[#7055FD]';
 
 const RoleTile = ({ role }) => {
   return (
@@ -34,7 +34,7 @@ const RoleTile = ({ role }) => {
 
 const RolesMobileCardCarousel = () => {
   return (
-    <Carousel effect={"cards"} grabCursor={true} modules={[EffectCards]}>
+    <Carousel effect={'cards'} grabCursor={true} modules={[EffectCards]}>
       {ROLES.map((role) => (
         <SwiperSlide key={role}>
           <RoleTile role={role} key={role} />
@@ -85,7 +85,7 @@ export default function Home() {
           <Heading>Coding</Heading>
           <TextSection>
             We seek to partner with <span className={STANDOUT_TEXT_CLASSES}>nonprofit impact causes</span> that have
-            projects on the go that need{" "}
+            projects on the go that need{' '}
             <span className={STANDOUT_TEXT_CLASSES}>additional programming and software development support</span>. We
             work with project managers, product designers, and analysts to turn project visions to quality software.
           </TextSection>
@@ -96,7 +96,7 @@ export default function Home() {
         <div className="flex flex-col md:w-1/2 md:pl-32 px-5 md:px-0 items-center py-10 md:py-0">
           <Heading underlineType={UnderlineTypes.GREEN_LONG_UNDERLINE}>Community</Heading>
           <TextSection>
-            Whether it’s through{" "}
+            Whether it’s through{' '}
             <span className={STANDOUT_TEXT_CLASSES}>code, workshops, donations, or volunteering</span>, we’re always
             looking to do something for our local communities! Every year, we donate to charities across Calgary and
             around the world. We also dedicate time volunteering at local organizations and host technical workshops
@@ -115,7 +115,7 @@ export default function Home() {
             <RoleTile role={role} key={role} />
           ))}
         </div>
-        <div className="md:hidden px-10">
+        <div className="md:hidden overflow-hidden px-10">
           <RolesMobileCardCarousel />
         </div>
         <div className="py-12 flex justify-center">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,6 +8,11 @@
 }
 
 @media (max-width: 768px) {
+  body,
+  html {
+    overflow-x: hidden;
+  }
+
   .text-stroke-outside {
     -webkit-text-stroke: 2px white;
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,11 +8,6 @@
 }
 
 @media (max-width: 768px) {
-  body,
-  html {
-    overflow-x: hidden;
-  }
-
   .text-stroke-outside {
     -webkit-text-stroke: 2px white;
   }


### PR DESCRIPTION
I had a similar problem when building the mobile view for my personal website, and although unconvential, there is nothing that you can do (that I know of, or that I found on S.O.) except add a global style to body/html to remove the horizontal scroll.

Before:
![image](https://github.com/Code-the-Change-YYC/code-the-change-yyc-site/assets/108391733/a70994f0-f458-4c6d-b4fe-7e1a7f033047)

After:
![image](https://github.com/Code-the-Change-YYC/code-the-change-yyc-site/assets/108391733/6d40f8ed-0d29-4f67-8e6f-0aa1dcb1932c)

While checking the other pages to make sure nothing else was affected, I also found this:
![image](https://github.com/Code-the-Change-YYC/code-the-change-yyc-site/assets/108391733/9d3be262-936c-4845-a6cd-5e8dc89b2c53)
On the Join page, the image is not centered. This is a quick fix and I can do it in this PR, but that's up to Topan/Armin.
