### PR TITLE
Changed reverse timeline order logic

### DIFF
--- a/components/Timeline.jsx
+++ b/components/Timeline.jsx
@@ -69,7 +69,7 @@ const Timeline = ({ timeline }) => {
     </div>
   );
 
-  const renderTimeline = timeline.reverse().map((props, index) => {
+  const renderTimeline = timeline.map((props, index) => {
     return isEven(index) ? EvenTimelineBlock(props) : OddTimelineBlock(props);
   });
 

--- a/pages/who-we-are/index.js
+++ b/pages/who-we-are/index.js
@@ -13,7 +13,7 @@ export async function getStaticProps() {
   const alumni = await fetchContent('alumni');
   alumni.sort((a, b) => a.orderNumber - b.orderNumber);
   const timeline = await fetchContent('timeline');
-  timeline.sort((a, b) => a.year - b.year);
+  timeline.sort((a, b) => b.year - a.year);
 
   return { props: { alumni, timeline } };
 }


### PR DESCRIPTION
- Initial logic reversed timeline order **_after_** it was fetched and passed to Timeline component using Reverse(). This had a bug where refreshing the About page would keep reversing the sort. 
- Changed the logic so that order is reversed **_as soon as_** it's fetched, before being passed to Timeline component. Bug is no longer there. 