### PR TITLE
WEB-57-Fix-FAQ-Tabs-Shifting

### DIFF
--- a/pages/who-we-are/index.js
+++ b/pages/who-we-are/index.js
@@ -48,7 +48,7 @@ const WhoWeAre = ({ alumni, timeline }) => {
       <Events />
       <Executives />
       <AlumniHighlights alumni={alumni} />
-      <div className="flex flex-col bg-white px-10 md:px-24 lg:px-48 w-full py-10">
+      <div className="flex flex-col bg-white px-10 md:px-24 lg:px-48 w-full py-10 overflow-y-auto scrollbar-hide" style={{height: 728 + 'px'}}>
         <Heading>FAQ</Heading>
         <div className="flex flex-col py-10 w-full space-y-4">
           {FAQS.map((props) => (


### PR DESCRIPTION
Made the height of the FAQ section fixed and made it scrollable on overflow instead of shifting the page.