### PR TITLE
Add revalidation handler for Contentful webhook updates

### DIFF
--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -1,0 +1,18 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  
+  if (req.query.secret !== process.env.REVALIDATE_SECRET) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  
+  try {
+    await res.revalidate('/events');
+    await res.revalidate('/who-we-are');
+    return res.json({ revalidated: true });
+  } catch (err) {
+    console.error('Revalidation error:', err);
+    return res.status(500).json({ message: 'Error revalidating', error: err.message });
+  }
+}


### PR DESCRIPTION
Added an API route to handle Contentful webhook events for dynamic content updates. The handler revalidates the `/events` and `/who-we-are` pages when triggered ensuring that updated content in Contentful is reflected on the site without waiting for redeployment.