### PR TITLE
spacing in events page

### DIFF
--- a/components/EventsBanner.jsx
+++ b/components/EventsBanner.jsx
@@ -14,7 +14,7 @@ const EventsBanner = () => {
   const handleClick = () => {};
 
   return (
-    <div className="flex flex-col bg-lilac text-center items-center pb-12 md:py-12">
+    <div className="flex flex-col bg-lilac text-center items-center pb-12 md:py-12 pt-12">
       <Heading classes="text-white text-4xl" underlineType={UnderlineTypes.BEIGE_SHORT_UNDERLINE}>
         Events
       </Heading>

--- a/components/EventsTiles.jsx
+++ b/components/EventsTiles.jsx
@@ -1,9 +1,9 @@
-import TextSection from './TextSection';
-import Heading from './Heading';
 import { EventTileImage } from './EventTileImage';
+import Heading from './Heading';
+import TextSection from './TextSection';
 
 const EVENTS_TILES_CONTAINER = 'w-4/5 mx-auto flex flex-wrap md:flex hidden';
-const EVENT_TILE = 'flex flex-col size-full bg-white rounded-3xl items-center px-4 justify-evenly';
+const EVENT_TILE = 'flex flex-col size-full bg-white rounded-3xl items-center px-4 justify-evenly pt-4';
 
 const EventTile = ({ eventName, description, image }) => {
   const descriptionText = description.content[0].content[0].value;

--- a/components/HackathonTimeline.jsx
+++ b/components/HackathonTimeline.jsx
@@ -1,10 +1,10 @@
-import Heading from './Heading';
 import Image from 'next/image';
-import { UnderlineTypes } from '../utils/underlineType';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { fetchContent } from '../api/apiRoot';
+import { UnderlineTypes } from '../utils/underlineType';
+import Heading from './Heading';
 
-const HACKATHON_TIMELINE_CONTAINER = 'flex justify-center bg-white';
+const HACKATHON_TIMELINE_CONTAINER = 'flex justify-center bg-white ';
 const HACKATHON_TIMELINE_CONTENT = 'max-w-[500px] w-[80vw] md:max-w-[1100px]';
 const HACKATHON_TIMELINE_HEADER = 'md:justify-start md:my-[60px] my-[30px] flex justify-center';
 

--- a/components/PastEventsCarousel.jsx
+++ b/components/PastEventsCarousel.jsx
@@ -1,14 +1,14 @@
 import Image from 'next/image';
-import { SwiperSlide } from 'swiper/react';
-import Tile from '../components/Tile';
-import TextSection from './TextSection';
-import Carousel from '../components/Carousel';
-import styles from '../components/RolesCarousel.module.css';
-import Heading from './Heading';
-import { UnderlineTypes } from '../utils/underlineType';
 import Link from 'next/link';
 import 'swiper/css/navigation';
+import { SwiperSlide } from 'swiper/react';
+import Carousel from '../components/Carousel';
+import styles from '../components/RolesCarousel.module.css';
+import Tile from '../components/Tile';
+import { UnderlineTypes } from '../utils/underlineType';
+import Heading from './Heading';
 import PastEventImage from './PastEventImage';
+import TextSection from './TextSection';
 
 const CAROUSEL_CONTAINER = styles.swiperContainer;
 const ARROW_INIT = { left: 'swiper-button-prev', right: 'swiper-button-next' };
@@ -16,7 +16,7 @@ const LEFT_NAVIGATION_ARROW = styles.swiperButtonPrev;
 const RIGHT_NAVIGATION_ARROW = styles.swiperButtonNext;
 
 const TILE_CONTAINER =
-  'flex flex-col xl:h-[650px] lg:h-[820px] md:flex-column md:h-[820px] h-[930px] rounded-[30px] p-[1.875rem]';
+  'flex flex-col xl:h-[650px] lg:h-[820px] md:flex-column md:h-[820px] h-[930px] rounded-[30px] p-[1.875rem] ';
 const TILE_IMAGE_CONTAINER = 'flex flex-row justify-center md:flex-row md:justify-around lg:justify-center relative';
 const TILE_TEXT_CONTAINER = 'basis-3/5 md:basis-3/5 lg:basis-3/5 text-center md:py-10 ';
 const TILE_TEXT_SPACING = 'lg:space-y-10 py-5';

--- a/components/UpcomingEvents.jsx
+++ b/components/UpcomingEvents.jsx
@@ -1,11 +1,11 @@
+import { UnderlineTypes } from '../utils/underlineType';
 import EventsCarousel from './EventsCarousel';
 import EventsTiles from './EventsTiles';
 import Heading from './Heading';
-import { UnderlineTypes } from '../utils/underlineType';
 
 const UpcomingEvents = ({ upcomingEvent }) => {
   return (
-    <div className="flex flex-col items-center bg-orange z-0 pb-12 md:pb-16 lg:pb-20">
+    <div className="flex flex-col items-center bg-orange z-0 pt-12 pb-12 md:pb-16 lg:pb-20">
       <div className="flex items-baseline space-x-4 mb-4">
         <h1 className="text-white text-3xl font-medium">Upcoming</h1>
         <Heading classes="text-white text-[2.25rem]" underlineType={UnderlineTypes.PURPLE_SHORT_UNDERLINE}>


### PR DESCRIPTION
added hackathon as upcoming event in CONTENTFUL and will fix spacing on the event page. lots of spacing/padding issues on mobile and desktop view. will investigate. 

<img width="1116" height="795" alt="Screenshot 2025-11-04 at 12 15 32 AM" src="https://github.com/user-attachments/assets/bfd5506e-2356-4847-a418-f66332a4193c" />

Going to make the upcoming events sort of like that with the boxes/fields inside and stuff. and have it link to the website/event signup page.

<img width="900" height="1125" alt="hackthechange2025poster" src="https://github.com/user-attachments/assets/14b46c0d-0a41-4b4c-ad87-6a9f94c3e3f2" />
Will use this poster 